### PR TITLE
Fix missing friendly_name

### DIFF
--- a/packages/core-dev.yaml
+++ b/packages/core-dev.yaml
@@ -25,6 +25,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
 
 esp32:
   board: esp32doit-devkit-v1
@@ -113,6 +114,6 @@ xiaomi_bslamp2:
     master1: output_master1
     master2: output_master2
   front_panel:
-    i2c: front_panel_i2c 
+    i2c: front_panel_i2c
     address: 0x2C
     trigger_pin: GPIO16

--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -16,6 +16,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
 
 esp32:
   board: esp32doit-devkit-v1
@@ -105,6 +106,6 @@ xiaomi_bslamp2:
     master1: output_master1
     master2: output_master2
   front_panel:
-    i2c: front_panel_i2c 
+    i2c: front_panel_i2c
     address: 0x2C
     trigger_pin: GPIO16


### PR DESCRIPTION
Fix missing `friendly_name` in `core{,-dev}.yaml` so that the set friendly name shows up in the ESPHome Dashboard and in Home Assistant.