### PR TITLE
Adding ignore_efuse_custom_mac config setting

### DIFF
--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -24,6 +24,7 @@ esp32:
     sdkconfig_options:
       CONFIG_FREERTOS_UNICORE: y
     advanced:
+      ignore_efuse_custom_mac: true
       ignore_efuse_mac_crc: true
 
 # Retrieve the code for the xiaomi_bslamp2 platform from GitHub.


### PR DESCRIPTION
Hey there,

related to this issue here, I've created this pull request: https://github.com/mmakaay/esphome-xiaomi_bslamp2/issues/130
However, I can't share the issue that the config won't compile at all or throws any error. For me the devices simply had a weird new MAC address.

There had been some changes in ESPHome (which should **clearly** have been marked as breaking change... Or at least a bit more prominent...) to how it makes use of burned in efuse MAC addresses, especially this one: https://github.com/esphome/esphome/pull/7498

Apparently, the burned in efuse MAC addresses are useless. After updating to ESPHome 2024.10.0, my two bedside lamps showed with these MAC addresses: B4-C3-FB-3F-00-00 & AC-C3-FB-3F-00-00.

It's enough to simply add the news config setting and set it to `false`, like in this PR.

Greetings,

Andy!