### PR TITLE
Fix memory leaks when transitions occur

### DIFF
--- a/components/xiaomi_bslamp2/light/color_handler_chain.h
+++ b/components/xiaomi_bslamp2/light/color_handler_chain.h
@@ -32,27 +32,27 @@ class ColorHandlerChain : public ColorHandler {
     // targeted classes. These classes are called here in a chain of
     // command-like pattern, to let the first one that can handle the light
     // settings do the honours.
-    if (off_light_->set_light_color_values(v))
-      off_light_->copy_to(this);
-    else if (night_light_->set_light_color_values(v))
-      night_light_->copy_to(this);
-    else if (white_light_->set_light_color_values(v))
-      white_light_->copy_to(this);
-    else if (rgb_light_->set_light_color_values(v))
-      rgb_light_->copy_to(this);
+    if (off_light_.set_light_color_values(v))
+      off_light_.copy_to(this);
+    else if (night_light_.set_light_color_values(v))
+      night_light_.copy_to(this);
+    else if (white_light_.set_light_color_values(v))
+      white_light_.copy_to(this);
+    else if (rgb_light_.set_light_color_values(v))
+      rgb_light_.copy_to(this);
     else {
       ESP_LOGE(TAG, "Light color error: (None of the ColorHandler classes handles the requested light state; defaulting to 'off'");
-      off_light_->copy_to(this);
+      off_light_.copy_to(this);
     }
 
     return true;
   }
 
  protected:
-  ColorHandler *off_light_ = new ColorHandlerOff();
-  ColorHandler *rgb_light_ = new ColorHandlerRGB();
-  ColorHandler *white_light_ = new ColorHandlerColorTemperature();
-  ColorHandler *night_light_ = new ColorHandlerNightLight();
+  ColorHandlerOff              off_light_;
+  ColorHandlerRGB              rgb_light_;
+  ColorHandlerColorTemperature white_light_;
+  ColorHandlerNightLight       night_light_;
 };
 
 }  // namespace bslamp2

--- a/components/xiaomi_bslamp2/light/light_output.h
+++ b/components/xiaomi_bslamp2/light/light_output.h
@@ -54,8 +54,8 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
   void write_state(light::LightState *state) {
     auto values = state->current_values;
 
-    color_handler_chain->set_light_color_values(values);
-    light_mode_callback_.call(color_handler_chain->light_mode);
+    color_handler_chain.set_light_color_values(values);
+    light_mode_callback_.call(color_handler_chain.light_mode);
     state_callback_.call(values);
 
     // Note: one might think that it is more logical to turn on the LED
@@ -67,7 +67,7 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
       light_->turn_on();
 
     // Apply the GPIO output levels as defined by the color handler.
-    light_->set_state(color_handler_chain);
+    light_->set_state(&color_handler_chain);
 
     if (values.get_state() == 0)
       light_->turn_off();
@@ -75,7 +75,7 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
 
  protected:
   LightHAL *light_;
-  ColorHandler *color_handler_chain = new ColorHandlerChain();
+  ColorHandlerChain color_handler_chain;
   CallbackManager<void(std::string)> light_mode_callback_{};
   CallbackManager<void(light::LightColorValues)> state_callback_{};
 };


### PR DESCRIPTION
Every time the light component parameters changed with a transition length > 0 
(e.g.,  `call.set_transition_length(1000)`), I observed a decrease in the heap size.

I think the reason is dynamic memory allocation that is not released afterwards:

in **color_handler_chain.h**:
```C
   ColorHandler *off_light_ = new ColorHandlerOff();
   ColorHandler *rgb_light_ = new ColorHandlerRGB();
   ColorHandler *white_light_ = new ColorHandlerColorTemperature();
   ColorHandler *night_light_ = new ColorHandlerNightLight();
```
and in **light_output.h**:
```C
   ColorHandler *color_handler_chain = new ColorHandlerChain();
```

I replaced dynamic memory allocation with static allocation.

Now I don't observe memory leaks any more.