### PR TITLE
Add version, manufacturer and modelnr

### DIFF
--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -17,6 +17,10 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
+  comment: "Xiaomi Mi Bedside Lamp 2"
+  project:
+      name: "Yeelight Technology.MJCTD02YL"
+      version: "2025.3.0"
 
 esp32:
   board: esp32doit-devkit-v1


### PR DESCRIPTION
The manufacturer and model strings are the same as with the original firmware. This will allow [powercalc](https://github.com/bramstroker/homeassistant-powercalc) to discover the device and automatically configure it with the correct power profile.

