### PR TITLE
Fix ESPHome 2025.11 compatibility: Update Action::play() method signature

### DIFF
--- a/components/xiaomi_bslamp2/light/automation.h
+++ b/components/xiaomi_bslamp2/light/automation.h
@@ -46,7 +46,7 @@ template<typename... Ts> class DiscoAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(float, color_temperature)
   TEMPLATABLE_VALUE(std::string, effect)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     if (this->disco_state_.has_value()) {
       auto p = this->disco_state_.optional_value(x...);
       if (!*p) {
@@ -83,7 +83,7 @@ template<typename... Ts> class ActivatePresetAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(std::string, group);
   TEMPLATABLE_VALUE(std::string, preset);
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     auto operation = this->operation_.value(x...);
 
     if (operation == "next_group") {

--- a/components/xiaomi_bslamp2/output/automation.h
+++ b/components/xiaomi_bslamp2/output/automation.h
@@ -17,7 +17,7 @@ template<typename... Ts> class SetLEDsAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(int, mode)
   TEMPLATABLE_VALUE(uint16_t, leds)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     uint16_t mode = this->mode_.value(x...);
     uint16_t value = this->leds_.value(x...);
     switch (mode) {
@@ -43,7 +43,7 @@ template<typename... Ts> class SetLevelAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(float, level)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     parent_->set_level(this->level_.value(x...));
     parent_->update_leds();
   }
@@ -56,7 +56,7 @@ template<typename... Ts> class UpdateLEDsAction : public Action<Ts...> {
  public:
   explicit UpdateLEDsAction(XiaomiBslamp2FrontPanelOutput *parent) : parent_(parent) {}
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     parent_->update_leds();
   }
 


### PR DESCRIPTION
Fixes #145

**Note:** This release requires ESPHome `2025.11` or newer. Will need to update dep from `2025.7.0`

- Update `play()` method signatures in automation classes to match ESPHome 2025.11 API
- Change from `Ts... x` to `const Ts &...x` parameter format
- Fixed in both `light/automation.h` and `output/automation.h` files
- Affects `ActivatePresetAction`, `DiscoAction`, `SetLEDsAction`, `SetLevelAction`, and `UpdateLEDsAction` classes
- Resolves compilation errors when building with ESPHome `2025.11+`