### PR TITLE
Fix light state not restored after power cycle

### DIFF
--- a/components/xiaomi_bslamp2/light/__init__.py
+++ b/components/xiaomi_bslamp2/light/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_EFFECT,
     CONF_FLASH_LENGTH,
+    CONF_RESTORE_MODE,
 )
 from .. import bslamp2_ns, CODEOWNERS, CONF_LIGHT_HAL_ID, LightHAL
 
@@ -93,6 +94,9 @@ CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
         cv.GenerateID(CONF_ID): cv.declare_id(XiaomiBslamp2LightState),
         cv.GenerateID(CONF_LIGHT_HAL_ID): cv.use_id(LightHAL),
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(XiaomiBslamp2LightOutput),
+        cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_OFF"): cv.enum(
+            light.RESTORE_MODES, upper=True, space="_"
+        ),
         cv.Optional(CONF_ON_BRIGHTNESS): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(BrightnessTrigger),

--- a/components/xiaomi_bslamp2/light/light_state.h
+++ b/components/xiaomi_bslamp2/light/light_state.h
@@ -8,19 +8,6 @@ namespace esphome {
 namespace xiaomi {
 namespace bslamp2 {
 
-// Can be replaced with light::LightStateRTCState once pull request
-// https://github.com/esphome/esphome/pull/1735 is merged.
-struct MyLightStateRTCState {
-  bool state{false};
-  float brightness{1.0f};
-  float red{1.0f};
-  float green{1.0f};
-  float blue{1.0f};
-  float white{1.0f};
-  float color_temp{1.0f};
-  uint32_t effect{0};
-};
-
 /**
  * A custom LightState class for the Xiaomi Bedside Lamp 2.
  *
@@ -32,22 +19,26 @@ class XiaomiBslamp2LightState : public light::LightState, public LightStateDisco
   XiaomiBslamp2LightState(XiaomiBslamp2LightOutput *output) : light::LightState(output) { }
 
   void disco_stop() {
-    MyLightStateRTCState recovered{};
+    light::LightStateRTCState recovered{};
     if (this->rtc_.load(&recovered)) {
       auto call = make_disco_call(true);
-	  call.set_state(recovered.state);
-	  call.set_brightness_if_supported(recovered.brightness);
-	  call.set_red_if_supported(recovered.red);
-	  call.set_green_if_supported(recovered.green);
-	  call.set_blue_if_supported(recovered.blue);
-	  call.set_white_if_supported(recovered.white);
-	  call.set_color_temperature_if_supported(recovered.color_temp);
-	  if (recovered.effect != 0) {
-		call.set_effect(recovered.effect);
-	  } else {
-		call.set_transition_length_if_supported(0);
-	  }
-	  call.perform();
+      call.set_state(recovered.state);
+      call.set_brightness_if_supported(recovered.brightness);
+      call.set_color_brightness_if_supported(recovered.color_brightness);
+      call.set_red_if_supported(recovered.red);
+      call.set_green_if_supported(recovered.green);
+      call.set_blue_if_supported(recovered.blue);
+      call.set_white_if_supported(recovered.white);
+      call.set_color_temperature_if_supported(recovered.color_temp);
+      call.set_cold_white_if_supported(recovered.cold_white);
+      call.set_warm_white_if_supported(recovered.warm_white);
+      if (recovered.effect != 0) {
+        call.set_effect(recovered.effect);
+      } else {
+        call.set_transition_length_if_supported(0);
+      }
+      call.set_color_mode_if_supported(recovered.color_mode);
+      call.perform();
     }
   }
 


### PR DESCRIPTION
ESPHome 2023.4.0 changed the default restore_mode
from RESTORE_DEFAULT_OFF to ALWAYS_OFF. Override
the default so state is saved to flash and restored on boot.

Also replace the obsolete MyLightStateRTCState
struct with ESPHome's LightStateRTCState. The old
struct had a different memory layout, causing
disco_stop() to read misaligned data.