### PR TITLE
feat: add night light calibration controls

### DIFF
--- a/components/xiaomi_bslamp2/light/__init__.py
+++ b/components/xiaomi_bslamp2/light/__init__.py
@@ -31,9 +31,13 @@ CONF_PRESET = "preset"
 CONF_PRESETS = "presets"
 CONF_NEXT = "next"
 CONF_GROUP = "group"
+CONF_NIGHT_CALIBRATION = "night_calibration"
 
 MIRED_MIN = 153
 MIRED_MAX = 588
+DEFAULT_NIGHT_LIGHT_RED = 0.968
+DEFAULT_NIGHT_LIGHT_GREEN = 0.968
+DEFAULT_NIGHT_LIGHT_BLUE = 0.972
 
 XiaomiBslamp2LightState = bslamp2_ns.class_("XiaomiBslamp2LightState", light.LightState)
 XiaomiBslamp2LightOutput = bslamp2_ns.class_("XiaomiBslamp2LightOutput", light.LightOutput)
@@ -96,6 +100,13 @@ CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(XiaomiBslamp2LightOutput),
         cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_OFF"): cv.enum(
             light.RESTORE_MODES, upper=True, space="_"
+        ),
+        cv.Optional(CONF_NIGHT_CALIBRATION, default={}): cv.Schema(
+            {
+                cv.Optional(CONF_RED, default=DEFAULT_NIGHT_LIGHT_RED): cv.float_range(min=0.0, max=1.0),
+                cv.Optional(CONF_GREEN, default=DEFAULT_NIGHT_LIGHT_GREEN): cv.float_range(min=0.0, max=1.0),
+                cv.Optional(CONF_BLUE, default=DEFAULT_NIGHT_LIGHT_BLUE): cv.float_range(min=0.0, max=1.0),
+            }
         ),
         cv.Optional(CONF_ON_BRIGHTNESS): automation.validate_automation(
             {
@@ -252,6 +263,14 @@ async def light_output_to_code(config):
     await light.register_light(light_output_var, config)
     light_hal_var = await cg.get_variable(config[CONF_LIGHT_HAL_ID])
     cg.add(light_output_var.set_parent(light_hal_var))
+    night_calibration = config[CONF_NIGHT_CALIBRATION]
+    cg.add(
+        light_output_var.set_night_light_color_temperature_calibration(
+            night_calibration[CONF_RED],
+            night_calibration[CONF_GREEN],
+            night_calibration[CONF_BLUE],
+        )
+    )
 
 
 async def on_brightness_to_code(config):

--- a/components/xiaomi_bslamp2/light/color_handler_chain.h
+++ b/components/xiaomi_bslamp2/light/color_handler_chain.h
@@ -27,6 +27,10 @@ namespace bslamp2 {
  */
 class ColorHandlerChain : public ColorHandler {
  public:
+  void set_night_light_color_temperature_calibration(float red, float green, float blue) {
+    night_light_.set_color_temperature_calibration(red, green, blue);
+  }
+
   bool set_light_color_values(light::LightColorValues v) {
     // The actual implementation of the various light modes is in separate
     // targeted classes. These classes are called here in a chain of

--- a/components/xiaomi_bslamp2/light/color_handler_chain.h
+++ b/components/xiaomi_bslamp2/light/color_handler_chain.h
@@ -27,8 +27,12 @@ namespace bslamp2 {
  */
 class ColorHandlerChain : public ColorHandler {
  public:
+  void set_night_light_color_temperature_calibration(NightLightCalibration calibration) {
+    night_light_.set_color_temperature_calibration(calibration);
+  }
+
   void set_night_light_color_temperature_calibration(float red, float green, float blue) {
-    night_light_.set_color_temperature_calibration(red, green, blue);
+    set_night_light_color_temperature_calibration({red, green, blue});
   }
 
   bool set_light_color_values(light::LightColorValues v) {

--- a/components/xiaomi_bslamp2/light/color_handler_night_light.h
+++ b/components/xiaomi_bslamp2/light/color_handler_night_light.h
@@ -9,6 +9,14 @@ namespace esphome {
 namespace xiaomi {
 namespace bslamp2 {
 
+struct NightLightCalibration {
+  float red;
+  float green;
+  float blue;
+};
+
+static const NightLightCalibration DEFAULT_NIGHT_LIGHT_CALIBRATION{0.968f, 0.968f, 0.972f};
+
 /**
  * This class can handle the GPIO outputs for the night light mode.
  *
@@ -25,10 +33,14 @@ namespace bslamp2 {
  */
 class ColorHandlerNightLight : public ColorHandler {
  public:
+  void set_color_temperature_calibration(NightLightCalibration calibration) {
+    color_temperature_calibration_.red = clamp(calibration.red, 0.0f, 1.0f);
+    color_temperature_calibration_.green = clamp(calibration.green, 0.0f, 1.0f);
+    color_temperature_calibration_.blue = clamp(calibration.blue, 0.0f, 1.0f);
+  }
+
   void set_color_temperature_calibration(float red, float green, float blue) {
-    color_temperature_red_ = clamp(red, 0.0f, 1.0f);
-    color_temperature_green_ = clamp(green, 0.0f, 1.0f);
-    color_temperature_blue_ = clamp(blue, 0.0f, 1.0f);
+    set_color_temperature_calibration({red, green, blue});
   }
 
   bool set_light_color_values(light::LightColorValues v) {
@@ -44,9 +56,9 @@ class ColorHandlerNightLight : public ColorHandler {
     // Based on measurements using the original device firmware, so it
     // matches the night light of the original firmware.
     if (v.get_color_mode() == light::ColorMode::COLOR_TEMPERATURE) {
-      red = color_temperature_red_;
-      green = color_temperature_green_;
-      blue = color_temperature_blue_;
+      red = color_temperature_calibration_.red;
+      green = color_temperature_calibration_.green;
+      blue = color_temperature_calibration_.blue;
       white = 0.0f;
     }
     // In RGB mode, the selected color is used to give the night light a
@@ -65,9 +77,7 @@ class ColorHandlerNightLight : public ColorHandler {
   }
 
  protected:
-  float color_temperature_red_{0.968f};
-  float color_temperature_green_{0.968f};
-  float color_temperature_blue_{0.972f};
+  NightLightCalibration color_temperature_calibration_{DEFAULT_NIGHT_LIGHT_CALIBRATION};
 };
 
 }  // namespace bslamp2

--- a/components/xiaomi_bslamp2/light/color_handler_night_light.h
+++ b/components/xiaomi_bslamp2/light/color_handler_night_light.h
@@ -3,6 +3,7 @@
 #include "../common.h"
 #include "../light_hal.h"
 #include "color_handler.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace xiaomi {
@@ -24,6 +25,12 @@ namespace bslamp2 {
  */
 class ColorHandlerNightLight : public ColorHandler {
  public:
+  void set_color_temperature_calibration(float red, float green, float blue) {
+    color_temperature_red_ = clamp(red, 0.0f, 1.0f);
+    color_temperature_green_ = clamp(green, 0.0f, 1.0f);
+    color_temperature_blue_ = clamp(blue, 0.0f, 1.0f);
+  }
+
   bool set_light_color_values(light::LightColorValues v) {
     light_mode = LIGHT_MODE_NIGHT;
 
@@ -37,9 +44,9 @@ class ColorHandlerNightLight : public ColorHandler {
     // Based on measurements using the original device firmware, so it
     // matches the night light of the original firmware.
     if (v.get_color_mode() == light::ColorMode::COLOR_TEMPERATURE) {
-      red = 0.968f;
-      green = 0.968f;
-      blue = 0.972f;
+      red = color_temperature_red_;
+      green = color_temperature_green_;
+      blue = color_temperature_blue_;
       white = 0.0f;
     }
     // In RGB mode, the selected color is used to give the night light a
@@ -56,6 +63,11 @@ class ColorHandlerNightLight : public ColorHandler {
 
     return true;
   }
+
+ protected:
+  float color_temperature_red_{0.968f};
+  float color_temperature_green_{0.968f};
+  float color_temperature_blue_{0.972f};
 };
 
 }  // namespace bslamp2

--- a/components/xiaomi_bslamp2/light/light_output.h
+++ b/components/xiaomi_bslamp2/light/light_output.h
@@ -23,6 +23,11 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
  public:
   void set_parent(LightHAL *light) { light_ = light; }
 
+  void set_night_light_color_temperature_calibration(float red, float green, float blue) {
+    color_handler_chain.set_night_light_color_temperature_calibration(red, green, blue);
+    apply_current_state();
+  }
+
   /**
    * Returns a LightTraits object, which is used to explain to the outside
    * world (e.g. Home Assistant) what features are supported by this device.
@@ -52,6 +57,7 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
    * Applies a requested light state to the physicial GPIO outputs.
    */
   void write_state(light::LightState *state) {
+    state_ = state;
     auto values = state->current_values;
 
     color_handler_chain.set_light_color_values(values);
@@ -73,8 +79,14 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
       light_->turn_off();
   }
 
+  void apply_current_state() {
+    if (state_ != nullptr)
+      write_state(state_);
+  }
+
  protected:
   LightHAL *light_;
+  light::LightState *state_{nullptr};
   ColorHandlerChain color_handler_chain;
   CallbackManager<void(std::string)> light_mode_callback_{};
   CallbackManager<void(light::LightColorValues)> state_callback_{};

--- a/components/xiaomi_bslamp2/light/light_output.h
+++ b/components/xiaomi_bslamp2/light/light_output.h
@@ -24,7 +24,8 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
   void set_parent(LightHAL *light) { light_ = light; }
 
   void set_night_light_color_temperature_calibration(float red, float green, float blue) {
-    color_handler_chain.set_night_light_color_temperature_calibration(red, green, blue);
+    night_light_calibration_ = {red, green, blue};
+    color_handler_chain.set_night_light_color_temperature_calibration(night_light_calibration_);
     apply_current_state();
   }
 
@@ -42,7 +43,10 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
 
   std::unique_ptr<light::LightTransformer> create_default_transition() override {
     return make_unique<XiaomiBslamp2LightTransitionTransformer>(
-      light_, &light_mode_callback_, &state_callback_);
+      light_,
+      &light_mode_callback_,
+      &state_callback_,
+      night_light_calibration_);
   }
 
   void add_on_light_mode_callback(std::function<void(std::string)> &&callback) {
@@ -90,6 +94,7 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
   ColorHandlerChain color_handler_chain;
   CallbackManager<void(std::string)> light_mode_callback_{};
   CallbackManager<void(light::LightColorValues)> state_callback_{};
+  NightLightCalibration night_light_calibration_{DEFAULT_NIGHT_LIGHT_CALIBRATION};
 };
 
 }  // namespace bslamp2

--- a/components/xiaomi_bslamp2/light/light_state.h
+++ b/components/xiaomi_bslamp2/light/light_state.h
@@ -2,6 +2,7 @@
 
 #include "../common.h"
 #include "interfaces.h"
+#include "light_output.h"
 #include "esphome/components/light/light_state.h"
 
 namespace esphome {
@@ -45,6 +46,11 @@ class XiaomiBslamp2LightState : public light::LightState, public LightStateDisco
   void disco_apply() {
     this->output_->write_state(this);
     this->next_write_ = false;
+  }
+
+  void set_night_light_color_temperature_calibration(float red, float green, float blue) {
+    auto *output = static_cast<XiaomiBslamp2LightOutput *>(this->output_);
+    output->set_night_light_color_temperature_calibration(red, green, blue);
   }
 
   light::LightCall make_disco_call(bool save_and_publish) {

--- a/components/xiaomi_bslamp2/light/light_transformer.h
+++ b/components/xiaomi_bslamp2/light/light_transformer.h
@@ -18,10 +18,12 @@ class XiaomiBslamp2LightTransitionTransformer : public light::LightTransitionTra
   explicit XiaomiBslamp2LightTransitionTransformer(
     LightHAL *light,
     CallbackManager<void(std::string)> *light_mode_callback,
-    CallbackManager<void(light::LightColorValues)> *state_callback) :
+    CallbackManager<void(light::LightColorValues)> *state_callback,
+    NightLightCalibration night_light_calibration) :
       light_(light),
       light_mode_callback_(light_mode_callback),
-      state_callback_(state_callback) { }
+      state_callback_(state_callback),
+      night_light_calibration_(night_light_calibration) { }
 
   bool is_finished() override {
       return force_finish_ || get_progress_() >= 1.0f;
@@ -31,6 +33,7 @@ class XiaomiBslamp2LightTransitionTransformer : public light::LightTransitionTra
     // Determine the GPIO outputs to use for the start and end point.
     // This light transition transformer will then transition linearly between them.
     light_->copy_to(&start_);
+    end_.set_night_light_color_temperature_calibration(night_light_calibration_);
     end_.set_light_color_values(target_values_);
 
     // Update the light mode of the light HAL to the target state, unless
@@ -53,11 +56,17 @@ class XiaomiBslamp2LightTransitionTransformer : public light::LightTransitionTra
   }
 
   optional<light::LightColorValues> apply() override { 
-    // When transitioning between night mode light colors, then do this immediately.
+    // When transitioning between off and night mode, or between night mode
+    // light colors, then do this immediately.
     // The LED driver circuitry is not capable of doing clean color or brightness
     // transitions at the low levels as used for the night light.
-    if (end_.light_mode == LIGHT_MODE_NIGHT && start_.light_mode == LIGHT_MODE_NIGHT) {
+    if ((end_.light_mode == LIGHT_MODE_NIGHT &&
+         (start_.light_mode == LIGHT_MODE_OFF || start_.light_mode == LIGHT_MODE_NIGHT)) ||
+        (end_.light_mode == LIGHT_MODE_OFF && start_.light_mode == LIGHT_MODE_NIGHT)) {
       light_->set_state(&end_);
+      if (end_.light_mode != LIGHT_MODE_OFF) {
+        light_->turn_on();
+      }
       force_finish_ = true;
     }
     // Otherwise perform a standard transformation.
@@ -92,6 +101,7 @@ class XiaomiBslamp2LightTransitionTransformer : public light::LightTransitionTra
   ColorHandlerChain end_{};
   CallbackManager<void(std::string)> *light_mode_callback_;
   CallbackManager<void(light::LightColorValues)> *state_callback_;
+  NightLightCalibration night_light_calibration_;
 };
 
 }  // namespace bslamp2

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -148,7 +148,7 @@ calibration controls that adjust a neutral calibration base by default:
 * `Night Light Level`: positive values make the night light brighter, negative values make it
   dimmer without changing the target color balance.
 
-By default, the package clamps the generated RGB attenuation values to the useful `0.960` ..
+By default, the package clamps the generated RGB attenuation values to the useful `0.920` ..
 `0.980` range and starts from a neutral equal-channel base. Both the clamp range and the
 calibration base values can be overridden with substitutions.
 
@@ -160,7 +160,7 @@ substitutions:
   night_light_calibration_red_base: "0.968"
   night_light_calibration_green_base: "0.968"
   night_light_calibration_blue_base: "0.968"
-  night_light_calibration_min: "0.960"
+  night_light_calibration_min: "0.920"
   night_light_calibration_max: "0.980"
 
 packages:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -116,13 +116,31 @@ light.
 
 ### Night light calibration
 
+The `xiaomi_bslamp2` light platform supports fixed YAML calibration for the color-temperature night
+light mode. These values are the base RGB attenuation levels for the night light:
+
+```yaml
+light:
+  - platform: xiaomi_bslamp2
+    id: my_light
+    night_calibration:
+      red: 0.968
+      green: 0.968
+      blue: 0.972
+```
+
+In `packages/core.yaml`, these values can also be changed through the `night_light_red`,
+`night_light_green` and `night_light_blue` substitutions. The defaults match the previous built-in
+night light calibration; use `0.968` for all three channels if you want a neutral equal-channel
+fixed YAML calibration.
+
 The `packages/night_light_calibration.yaml` package exposes Home Assistant controls for tuning the
 night light white balance while the lamp is on. This is useful when the color-temperature night
 light mode looks too green, too blue or otherwise uneven.
 
 Internally, this mode uses calibrated RGB attenuation levels. Larger attenuation values dim a color
 channel, so editing raw RGB values directly can feel backwards. The package exposes three easier
-calibration controls instead:
+calibration controls that adjust a neutral calibration base by default:
 
 * `Night Light Tint`: positive values reduce green and move the night light toward magenta.
 * `Night Light Temperature`: positive values make the result warmer/amber, negative values make it
@@ -131,17 +149,17 @@ calibration controls instead:
   dimmer without changing the target color balance.
 
 By default, the package clamps the generated RGB attenuation values to the useful `0.960` ..
-`0.980` range and starts from a neutral equal-channel base. Both the clamp range and the base
-values can be overridden with substitutions.
+`0.980` range and starts from a neutral equal-channel base. Both the clamp range and the
+calibration base values can be overridden with substitutions.
 
 ```yaml
 substitutions:
   night_light_tint_initial: "0.0"
   night_light_temperature_initial: "0.0"
   night_light_level_initial: "0.0"
-  night_light_red_calibration_base: "0.968"
-  night_light_green_calibration_base: "0.968"
-  night_light_blue_calibration_base: "0.968"
+  night_light_calibration_red_base: "0.968"
+  night_light_calibration_green_base: "0.968"
+  night_light_calibration_blue_base: "0.968"
   night_light_calibration_min: "0.960"
   night_light_calibration_max: "0.980"
 
@@ -153,8 +171,9 @@ packages:
       - packages/night_light_calibration.yaml
 ```
 
-Changing these values applies immediately, so the lamp can be calibrated while the night light is
-on.
+Changing the fixed YAML `night_calibration` values requires rebuilding and uploading the firmware.
+Changing the Home Assistant calibration controls applies immediately, so the lamp can be tuned while
+the night light is on.
 
 For development, `packages/night_light_calibration_dev.yaml` can be used instead of
 `packages/night_light_calibration.yaml`. It exposes raw red, green and blue attenuation inputs. Do

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -22,6 +22,7 @@ components of the lamp.
   |                            |  [sensor](#component-sensor) (touched slider level)              |
   | Front Panel Illumination   |  [output](#component-output) (on/off + indicator level)          |
   | Light mode propagation     |  [text_sensor](#component-text_sensor)                           |
+  | Night light calibration    |  [template number](#night-light-calibration)                     |
 
 ## Platform: xiaomi_bslamp2
 
@@ -112,6 +113,53 @@ mode. This makes things a lot easier to control.
 It is possible to control the night light mode separately. An example of this can be found in the
 [example.yaml](../example.yaml), in which holding the power button is bound to activating the night
 light.
+
+### Night light calibration
+
+The `packages/night_light_calibration.yaml` package exposes Home Assistant controls for tuning the
+night light white balance while the lamp is on. This is useful when the color-temperature night
+light mode looks too green, too blue or otherwise uneven.
+
+Internally, this mode uses calibrated RGB attenuation levels. Larger attenuation values dim a color
+channel, so editing raw RGB values directly can feel backwards. The package exposes three easier
+calibration controls instead:
+
+* `Night Light Tint`: positive values reduce green and move the night light toward magenta.
+* `Night Light Temperature`: positive values make the result warmer/amber, negative values make it
+  cooler/bluer.
+* `Night Light Level`: positive values make the night light brighter, negative values make it
+  dimmer without changing the target color balance.
+
+By default, the package clamps the generated RGB attenuation values to the useful `0.960` ..
+`0.980` range and starts from a neutral equal-channel base. Both the clamp range and the base
+values can be overridden with substitutions.
+
+```yaml
+substitutions:
+  night_light_tint_initial: "0.0"
+  night_light_temperature_initial: "0.0"
+  night_light_level_initial: "0.0"
+  night_light_red_calibration_base: "0.968"
+  night_light_green_calibration_base: "0.968"
+  night_light_blue_calibration_base: "0.968"
+  night_light_calibration_min: "0.960"
+  night_light_calibration_max: "0.980"
+
+packages:
+  bslamp2:
+    files:
+      - packages/core.yaml
+      - packages/behavior_default.yaml
+      - packages/night_light_calibration.yaml
+```
+
+Changing these values applies immediately, so the lamp can be calibrated while the night light is
+on.
+
+For development, `packages/night_light_calibration_dev.yaml` can be used instead of
+`packages/night_light_calibration.yaml`. It exposes raw red, green and blue attenuation inputs. Do
+not include both calibration packages in the same device configuration, because they control the
+same night light calibration target.
 
 ### `light.disco_on` Action
 

--- a/example.yaml
+++ b/example.yaml
@@ -15,6 +15,15 @@ substitutions:
 
   #light_name: RGBWW Light
   #light_mode_text_sensor_name: Light Mode
+  #night_light_tint_name: Night Light Tint
+  #night_light_temperature_name: Night Light Temperature
+  #night_light_level_name: Night Light Level
+  #night_light_tint_initial: "0.0"
+  #night_light_temperature_initial: "0.0"
+  #night_light_level_initial: "0.0"
+  #night_light_red_calibration_base: "0.968"
+  #night_light_green_calibration_base: "0.968"
+  #night_light_blue_calibration_base: "0.968"
   #default_transition_length: 800ms
 
 # --------------------------------------------------------------------------
@@ -28,10 +37,11 @@ substitutions:
 # an example for your own customizations.
 #
 # Available packages are:
-# - core.yaml                : core components & hardware setup
-# - behavior_default.yaml    : default device behavior
-# - ota_feedback.yaml        : enable visual feedback during OTA updates
-# - activate_preset_svc.yaml : 'activate_preset' service for Home Assistant
+# - core.yaml                        : core components & hardware setup
+# - behavior_default.yaml            : default device behavior
+# - night_light_calibration.yaml     : HA controls for night light tint calibration
+# - ota_feedback.yaml                : enable visual feedback during OTA updates
+# - activate_preset_svc.yaml         : 'activate_preset' service for Home Assistant
 # --------------------------------------------------------------------------
 
 packages:
@@ -41,6 +51,7 @@ packages:
     files:
       - packages/core.yaml
       - packages/behavior_default.yaml
+      - packages/night_light_calibration.yaml
       - packages/ota_feedback.yaml
       - packages/activate_preset_svc.yaml
     refresh: 0s
@@ -60,4 +71,3 @@ api:
 ota:
   platform: esphome
   password: !secret ota_password
-

--- a/example.yaml
+++ b/example.yaml
@@ -9,9 +9,8 @@ substitutions:
   name: bedside-lamp
   friendly_name: Bedside Lamp
 
-  # Below are some default values as provided by the core.yaml configuration
-  # package. You can uncomment these and change them if you do not like the
-  # default values.
+  # Below are some default values as provided by the configuration packages.
+  # You can uncomment these and change them if you do not like the defaults.
 
   #light_name: RGBWW Light
   #light_mode_text_sensor_name: Light Mode
@@ -21,9 +20,14 @@ substitutions:
   #night_light_tint_initial: "0.0"
   #night_light_temperature_initial: "0.0"
   #night_light_level_initial: "0.0"
-  #night_light_red_calibration_base: "0.968"
-  #night_light_green_calibration_base: "0.968"
-  #night_light_blue_calibration_base: "0.968"
+  #night_light_red: "0.968"
+  #night_light_green: "0.968"
+  #night_light_blue: "0.972"
+  #night_light_calibration_red_base: "0.968"
+  #night_light_calibration_green_base: "0.968"
+  #night_light_calibration_blue_base: "0.968"
+  #night_light_calibration_min: "0.960"
+  #night_light_calibration_max: "0.980"
   #default_transition_length: 800ms
 
 # --------------------------------------------------------------------------
@@ -39,7 +43,7 @@ substitutions:
 # Available packages are:
 # - core.yaml                        : core components & hardware setup
 # - behavior_default.yaml            : default device behavior
-# - night_light_calibration.yaml     : HA controls for night light tint calibration
+# - night_light_calibration.yaml     : HA controls for night light calibration
 # - ota_feedback.yaml                : enable visual feedback during OTA updates
 # - activate_preset_svc.yaml         : 'activate_preset' service for Home Assistant
 # --------------------------------------------------------------------------

--- a/example.yaml
+++ b/example.yaml
@@ -26,7 +26,7 @@ substitutions:
   #night_light_calibration_red_base: "0.968"
   #night_light_calibration_green_base: "0.968"
   #night_light_calibration_blue_base: "0.968"
-  #night_light_calibration_min: "0.960"
+  #night_light_calibration_min: "0.920"
   #night_light_calibration_max: "0.980"
   #default_transition_length: 800ms
 

--- a/packages/behavior_default.yaml
+++ b/packages/behavior_default.yaml
@@ -63,6 +63,10 @@ light:
     id: my_light
     name: ${light_name}
     default_transition_length: ${default_transition_length}
+    night_calibration:
+      red: ${night_light_red}
+      green: ${night_light_green}
+      blue: ${night_light_blue}
 
     # When the brightness changes, update the front panel illumination.
     on_brightness:

--- a/packages/core-dev.yaml
+++ b/packages/core-dev.yaml
@@ -17,6 +17,9 @@ substitutions:
   friendly_name: Bedside Lamp
   light_name: RGBWW Light
   light_mode_text_sensor_name: Light Mode
+  night_light_red: "0.968"
+  night_light_green: "0.968"
+  night_light_blue: "0.972"
   default_transition_length: 800ms
 
 # --------------------------------------------------------------------------

--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -8,6 +8,9 @@ substitutions:
   friendly_name: Bedside Lamp
   light_name: RGBWW Light
   light_mode_text_sensor_name: Light Mode
+  night_light_red: "0.968"
+  night_light_green: "0.968"
+  night_light_blue: "0.972"
   default_transition_length: 800ms
 
 # --------------------------------------------------------------------------

--- a/packages/night_light_calibration.yaml
+++ b/packages/night_light_calibration.yaml
@@ -7,15 +7,15 @@
 # ------------------------------------------------------------------------
 
 substitutions:
+  night_light_calibration_red_base: "0.968"
+  night_light_calibration_green_base: "0.968"
+  night_light_calibration_blue_base: "0.968"
   night_light_tint_name: Night Light Tint
   night_light_temperature_name: Night Light Temperature
   night_light_level_name: Night Light Level
   night_light_tint_initial: "0.0"
   night_light_temperature_initial: "0.0"
   night_light_level_initial: "0.0"
-  night_light_red_calibration_base: "0.968"
-  night_light_green_calibration_base: "0.968"
-  night_light_blue_calibration_base: "0.968"
   night_light_calibration_min: "0.960"
   night_light_calibration_max: "0.980"
 
@@ -48,13 +48,13 @@ script:
           // Positive level means brighter, so all attenuation values go down.
           const float level_amount = level * 0.001f;
 
-          const float red = clamp(${night_light_red_calibration_base}f - level_amount -
+          const float red = clamp(${night_light_calibration_red_base}f - level_amount -
                                       (tint_amount * 0.5f) - (temperature_amount * 0.5f),
                                   ${night_light_calibration_min}f, ${night_light_calibration_max}f);
-          const float green = clamp(${night_light_green_calibration_base}f - level_amount +
+          const float green = clamp(${night_light_calibration_green_base}f - level_amount +
                                         tint_amount - (temperature_amount * 0.25f),
                                     ${night_light_calibration_min}f, ${night_light_calibration_max}f);
-          const float blue = clamp(${night_light_blue_calibration_base}f - level_amount -
+          const float blue = clamp(${night_light_calibration_blue_base}f - level_amount -
                                        (tint_amount * 0.5f) + (temperature_amount * 0.75f),
                                    ${night_light_calibration_min}f, ${night_light_calibration_max}f);
 

--- a/packages/night_light_calibration.yaml
+++ b/packages/night_light_calibration.yaml
@@ -1,0 +1,108 @@
+# ------------------------------------------------------------------------
+# Night light color-temperature calibration
+#
+# This package exposes Home Assistant number entities for tuning the night
+# light tint without manipulating raw RGB attenuation values directly.
+# Values are restored by the standard ESPHome template number component.
+# ------------------------------------------------------------------------
+
+substitutions:
+  night_light_tint_name: Night Light Tint
+  night_light_temperature_name: Night Light Temperature
+  night_light_level_name: Night Light Level
+  night_light_tint_initial: "0.0"
+  night_light_temperature_initial: "0.0"
+  night_light_level_initial: "0.0"
+  night_light_red_calibration_base: "0.968"
+  night_light_green_calibration_base: "0.968"
+  night_light_blue_calibration_base: "0.968"
+  night_light_calibration_min: "0.960"
+  night_light_calibration_max: "0.980"
+
+esphome:
+  on_boot:
+    - priority: 600
+      then:
+        - script.execute: apply_night_light_calibration
+
+script:
+  - id: apply_night_light_calibration
+    mode: restart
+    then:
+      - lambda: |-
+          if (isnan(id(my_night_light_tint).state) ||
+              isnan(id(my_night_light_temperature).state) ||
+              isnan(id(my_night_light_level).state)) {
+            return;
+          }
+
+          const float tint = id(my_night_light_tint).state;
+          const float temperature = id(my_night_light_temperature).state;
+          const float level = id(my_night_light_level).state;
+
+          // Positive tint means less green / more magenta. These are attenuation
+          // values, so increasing green makes the green channel dimmer.
+          const float tint_amount = tint * 0.001f;
+          // Positive temperature means warmer / more amber, so blue is dimmed.
+          const float temperature_amount = temperature * 0.001f;
+          // Positive level means brighter, so all attenuation values go down.
+          const float level_amount = level * 0.001f;
+
+          const float red = clamp(${night_light_red_calibration_base}f - level_amount -
+                                      (tint_amount * 0.5f) - (temperature_amount * 0.5f),
+                                  ${night_light_calibration_min}f, ${night_light_calibration_max}f);
+          const float green = clamp(${night_light_green_calibration_base}f - level_amount +
+                                        tint_amount - (temperature_amount * 0.25f),
+                                    ${night_light_calibration_min}f, ${night_light_calibration_max}f);
+          const float blue = clamp(${night_light_blue_calibration_base}f - level_amount -
+                                       (tint_amount * 0.5f) + (temperature_amount * 0.75f),
+                                   ${night_light_calibration_min}f, ${night_light_calibration_max}f);
+
+          id(my_light).set_night_light_color_temperature_calibration(red, green, blue);
+
+number:
+  - platform: template
+    id: my_night_light_tint
+    name: ${night_light_tint_name}
+    icon: mdi:palette
+    entity_category: config
+    mode: slider
+    optimistic: true
+    restore_value: true
+    min_value: -10.0
+    max_value: 10.0
+    step: 0.1
+    initial_value: ${night_light_tint_initial}
+    on_value:
+      then:
+        - script.execute: apply_night_light_calibration
+  - platform: template
+    id: my_night_light_temperature
+    name: ${night_light_temperature_name}
+    icon: mdi:thermometer
+    entity_category: config
+    mode: slider
+    optimistic: true
+    restore_value: true
+    min_value: -10.0
+    max_value: 10.0
+    step: 0.1
+    initial_value: ${night_light_temperature_initial}
+    on_value:
+      then:
+        - script.execute: apply_night_light_calibration
+  - platform: template
+    id: my_night_light_level
+    name: ${night_light_level_name}
+    icon: mdi:brightness-6
+    entity_category: config
+    mode: slider
+    optimistic: true
+    restore_value: true
+    min_value: -10.0
+    max_value: 10.0
+    step: 0.1
+    initial_value: ${night_light_level_initial}
+    on_value:
+      then:
+        - script.execute: apply_night_light_calibration

--- a/packages/night_light_calibration.yaml
+++ b/packages/night_light_calibration.yaml
@@ -16,7 +16,7 @@ substitutions:
   night_light_tint_initial: "0.0"
   night_light_temperature_initial: "0.0"
   night_light_level_initial: "0.0"
-  night_light_calibration_min: "0.960"
+  night_light_calibration_min: "0.920"
   night_light_calibration_max: "0.980"
 
 esphome:
@@ -40,22 +40,36 @@ script:
           const float temperature = id(my_night_light_temperature).state;
           const float level = id(my_night_light_level).state;
 
-          // Positive tint means less green / more magenta. These are attenuation
-          // values, so increasing green makes the green channel dimmer.
-          const float tint_amount = tint * 0.001f;
-          // Positive temperature means warmer / more amber, so blue is dimmed.
-          const float temperature_amount = temperature * 0.001f;
-          // Positive level means brighter, so all attenuation values go down.
-          const float level_amount = level * 0.001f;
+          const float base_red_drive = 1.0f - ${night_light_calibration_red_base}f;
+          const float base_green_drive = 1.0f - ${night_light_calibration_green_base}f;
+          const float base_blue_drive = 1.0f - ${night_light_calibration_blue_base}f;
 
-          const float red = clamp(${night_light_calibration_red_base}f - level_amount -
-                                      (tint_amount * 0.5f) - (temperature_amount * 0.5f),
+          auto approx_exp = [](float x) -> float {
+            return 1.0f + x + 0.5f * x * x;
+          };
+
+          // Work in drive space, where larger values mean a brighter channel.
+          // Quadratic gain approximation keeps tint and temperature perceptible
+          // without pulling in runtime exponential math.
+          const float level_gain = approx_exp(level * 0.027f);
+          const float temperature_amount = temperature * 0.027f;
+          const float tint_amount = tint * 0.035f;
+
+          const float red_drive = base_red_drive * level_gain *
+                                  approx_exp(temperature_amount * 0.5f) *
+                                  approx_exp(tint_amount * 0.5f);
+          const float green_drive = base_green_drive * level_gain *
+                                    approx_exp(temperature_amount * 0.25f) *
+                                    approx_exp(-tint_amount);
+          const float blue_drive = base_blue_drive * level_gain *
+                                   approx_exp(-temperature_amount * 0.75f) *
+                                   approx_exp(tint_amount * 0.5f);
+
+          const float red = clamp(1.0f - red_drive,
                                   ${night_light_calibration_min}f, ${night_light_calibration_max}f);
-          const float green = clamp(${night_light_calibration_green_base}f - level_amount +
-                                        tint_amount - (temperature_amount * 0.25f),
+          const float green = clamp(1.0f - green_drive,
                                     ${night_light_calibration_min}f, ${night_light_calibration_max}f);
-          const float blue = clamp(${night_light_calibration_blue_base}f - level_amount -
-                                       (tint_amount * 0.5f) + (temperature_amount * 0.75f),
+          const float blue = clamp(1.0f - blue_drive,
                                    ${night_light_calibration_min}f, ${night_light_calibration_max}f);
 
           id(my_light).set_night_light_color_temperature_calibration(red, green, blue);
@@ -85,7 +99,7 @@ number:
     optimistic: true
     restore_value: true
     min_value: -10.0
-    max_value: 10.0
+    max_value: 20.0
     step: 0.1
     initial_value: ${night_light_temperature_initial}
     on_value:
@@ -100,7 +114,7 @@ number:
     optimistic: true
     restore_value: true
     min_value: -10.0
-    max_value: 10.0
+    max_value: 20.0
     step: 0.1
     initial_value: ${night_light_level_initial}
     on_value:

--- a/packages/night_light_calibration_dev.yaml
+++ b/packages/night_light_calibration_dev.yaml
@@ -12,7 +12,7 @@ substitutions:
   night_light_raw_red_calibration_initial: "0.968"
   night_light_raw_green_calibration_initial: "0.968"
   night_light_raw_blue_calibration_initial: "0.968"
-  night_light_raw_calibration_min: "0.960"
+  night_light_raw_calibration_min: "0.920"
   night_light_raw_calibration_max: "0.980"
 
 esphome:

--- a/packages/night_light_calibration_dev.yaml
+++ b/packages/night_light_calibration_dev.yaml
@@ -1,0 +1,92 @@
+# ------------------------------------------------------------------------
+# Night light color-temperature calibration: raw developer controls
+#
+# Use this package instead of night_light_calibration.yaml when you want
+# direct RGB attenuation inputs for calibration experiments.
+# ------------------------------------------------------------------------
+
+substitutions:
+  night_light_raw_red_calibration_name: Night Light Raw Red Calibration
+  night_light_raw_green_calibration_name: Night Light Raw Green Calibration
+  night_light_raw_blue_calibration_name: Night Light Raw Blue Calibration
+  night_light_raw_red_calibration_initial: "0.968"
+  night_light_raw_green_calibration_initial: "0.968"
+  night_light_raw_blue_calibration_initial: "0.968"
+  night_light_raw_calibration_min: "0.960"
+  night_light_raw_calibration_max: "0.980"
+
+esphome:
+  on_boot:
+    - priority: 600
+      then:
+        - script.execute: apply_raw_night_light_calibration
+
+script:
+  - id: apply_raw_night_light_calibration
+    mode: restart
+    then:
+      - lambda: |-
+          if (isnan(id(my_night_light_raw_red_calibration).state) ||
+              isnan(id(my_night_light_raw_green_calibration).state) ||
+              isnan(id(my_night_light_raw_blue_calibration).state)) {
+            return;
+          }
+
+          const float red = clamp(id(my_night_light_raw_red_calibration).state,
+                                  ${night_light_raw_calibration_min}f,
+                                  ${night_light_raw_calibration_max}f);
+          const float green = clamp(id(my_night_light_raw_green_calibration).state,
+                                    ${night_light_raw_calibration_min}f,
+                                    ${night_light_raw_calibration_max}f);
+          const float blue = clamp(id(my_night_light_raw_blue_calibration).state,
+                                   ${night_light_raw_calibration_min}f,
+                                   ${night_light_raw_calibration_max}f);
+
+          id(my_light).set_night_light_color_temperature_calibration(red, green, blue);
+
+number:
+  - platform: template
+    id: my_night_light_raw_red_calibration
+    name: ${night_light_raw_red_calibration_name}
+    icon: mdi:palette-swatch
+    entity_category: config
+    mode: box
+    optimistic: true
+    restore_value: true
+    min_value: ${night_light_raw_calibration_min}
+    max_value: ${night_light_raw_calibration_max}
+    step: 0.001
+    initial_value: ${night_light_raw_red_calibration_initial}
+    on_value:
+      then:
+        - script.execute: apply_raw_night_light_calibration
+  - platform: template
+    id: my_night_light_raw_green_calibration
+    name: ${night_light_raw_green_calibration_name}
+    icon: mdi:palette-swatch
+    entity_category: config
+    mode: box
+    optimistic: true
+    restore_value: true
+    min_value: ${night_light_raw_calibration_min}
+    max_value: ${night_light_raw_calibration_max}
+    step: 0.001
+    initial_value: ${night_light_raw_green_calibration_initial}
+    on_value:
+      then:
+        - script.execute: apply_raw_night_light_calibration
+  - platform: template
+    id: my_night_light_raw_blue_calibration
+    name: ${night_light_raw_blue_calibration_name}
+    icon: mdi:palette-swatch
+    entity_category: config
+    mode: box
+    optimistic: true
+    restore_value: true
+    min_value: ${night_light_raw_calibration_min}
+    max_value: ${night_light_raw_calibration_max}
+    step: 0.001
+    initial_value: ${night_light_raw_blue_calibration_initial}
+    on_value:
+      then:
+        - script.execute: apply_raw_night_light_calibration


### PR DESCRIPTION
## Summary

This PR adds configurable calibration for color-temperature night mode.

Solves #75.

The `xiaomi_bslamp2` light platform now supports fixed YAML calibration through the `night_calibration` option:

```yaml
night_calibration:
  red: 0.968
  green: 0.968
  blue: 0.972
```

The new calibration package exposes three Home Assistant config entities:

- `Night Light Tint`
- `Night Light Temperature`
- `Night Light Level`

These controls adjust the RGB attenuation values used by night light color-temperature mode, making it much easier to tune lamps that have a green, blue, or otherwise uneven tint. Values are restored by ESPHome and applied immediately, so calibration can be done live while the lamp is on.

An optional developer package is also included for direct raw RGB calibration.

## Notes

- Calibration only affects night light color-temperature mode.
- RGB night light mode and regular white/RGB modes keep their existing behavior.
- Fixed YAML calibration defaults match the previous built-in behavior.
- Home Assistant calibration starts from a neutral equal-channel base by default.
- Package substitutions can override both the fixed YAML defaults and the live calibration base.
- The generated RGB attenuation values are clamped to the useful night light range.

## Validation

- Ran formatting and project checks.
- Validated ESPHome config with the normal calibration package.
- Validated ESPHome config with the raw developer calibration package.
- Compiled firmware successfully for a real lamp configuration.
- Tested live calibration and power-cycle restore on physical lamps.
